### PR TITLE
Support quoted coordinate values in turf-midpoint.

### DIFF
--- a/index.js
+++ b/index.js
@@ -49,9 +49,9 @@ module.exports = function(point1, point2) {
   var y1 = point1.geometry.coordinates[1];
   var y2 = point2.geometry.coordinates[1];
 
-  var x3 = x1 + x2;
+  var x3 = Number(x1) + Number(x2);
   var midX = x3/2;
-  var y3 = y1 + y2;
+  var y3 = Number(y1) + Number(y2);
   var midY = y3/2;
 
   return point([midX, midY]);

--- a/test.js
+++ b/test.js
@@ -57,5 +57,13 @@ test('midpoint', function(t){
    };
   t.deepEqual(actualMidPoint, expectedMidPoint, 'should return the halfway point shown in the README example.');
 
+  var pt1 = {"type":"Feature","geometry":{"type":"Point","coordinates":["-86.48575050088414","39.16626837798435"]},"properties":{}};
+  var pt2 = {"type":"Feature","geometry":{"type":"Point","coordinates":["-86.5348237161408" ,"39.16786172034318"]},"properties":{}};
+  var expectedMidPoint = {"type":"Feature","geometry":{"type":"Point","coordinates":[ -86.51028710851247, 39.16706504916377 ]},"properties":{}};
+  var actualMidPoint = midpoint(pt1, pt2);
+  t.deepEqual(actualMidPoint, expectedMidPoint, 'should support quoted coordinate values');
+
+
+
   t.end();
 });

--- a/test.js
+++ b/test.js
@@ -21,5 +21,41 @@ test('midpoint', function(t){
   var actualMidPoint = midpoint(pt1, pt2);
   t.deepEqual(actualMidPoint, expectedMidPoint, 'should return the halfway point of a diagonal line starting off 1,1');
 
+  var pt1 = point([1,1]);
+  var pt2 = point([11,11]);
+  var expectedMidPoint = point([6, 6]);
+  var actualMidPoint = midpoint(pt1, pt2);
+  t.deepEqual(actualMidPoint, expectedMidPoint, 'should return the halfway point of a diagonal line starting off 1,1');
+
+  var pt1 = {
+    "type": "Feature",
+    "properties": {},
+    "geometry": {
+      "type": "Point",
+      "coordinates": [144.834823, -37.771257]
+    }
+  };
+  var pt2 = {
+    "type": "Feature",
+    "properties": {},
+    "geometry": {
+      "type": "Point",
+      "coordinates": [145.14244, -37.830937]
+    }
+  };
+  var actualMidPoint = midpoint(pt1, pt2);
+  var expectedMidPoint = {
+      "type": "Feature",
+      "geometry": {
+        "type": "Point",
+        "coordinates": [
+          144.9886315,
+          -37.801097
+        ]
+      },
+      "properties": {}
+   };
+  t.deepEqual(actualMidPoint, expectedMidPoint, 'should return the halfway point shown in the README example.');
+
   t.end();
 });


### PR DESCRIPTION
Without the fix, the "+" operator would concatenate values instead of
adding them, resulting in a "NaN" result instead of a sensible value.

While it would be ideal if the input coordinate values were _not_ quoted,
we follow the principle that should be "liberal in what you accept, and strict
in what you produce".
